### PR TITLE
Convert native arrays and booleans to strings in POST params

### DIFF
--- a/src/PaymentSpring.php
+++ b/src/PaymentSpring.php
@@ -60,6 +60,13 @@ class PaymentSpring {
   
   public static function constructPostRequest($options, $params){
     $options[CURLOPT_POST] = TRUE;
+    foreach($params as $k => $v){
+      if(is_array($v)){
+        $params[$k] = json_encode($v);
+      } elseif is_bool($v) {
+        $params[$k] = $v ? 'true' : 'false';
+      }
+    }
     $options[CURLOPT_POSTFIELDS] = json_encode($params);
     return $options;
   }

--- a/src/PaymentSpring.php
+++ b/src/PaymentSpring.php
@@ -63,7 +63,7 @@ class PaymentSpring {
     foreach($params as $k => $v){
       if(is_array($v)){
         $params[$k] = json_encode($v);
-      } elseif is_bool($v) {
+      } elseif (is_bool($v)) {
         $params[$k] = $v ? 'true' : 'false';
       }
     }

--- a/src/PaymentSpring.php
+++ b/src/PaymentSpring.php
@@ -61,7 +61,7 @@ class PaymentSpring {
   public static function constructPostRequest($options, $params){
     $options[CURLOPT_POST] = TRUE;
     foreach($params as $k => $v){
-      if(is_array($v)){
+      if(is_array($v) || is_object($v)){
         $params[$k] = json_encode($v);
       } elseif (is_bool($v)) {
         $params[$k] = $v ? 'true' : 'false';


### PR DESCRIPTION
I found that non-string and integer values in the JSON generated errors like "Can't convert FalseClass into String" or "Can't convert Hash into String".